### PR TITLE
update chglog 2572761

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,49 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,29 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/kohirens/version-release-orb
+options:
+  commits:
+    filters:
+      Type:
+        - add
+        - fix
+        - dep
+        - chg
+        - rmv
+  commit_groups:
+    title_maps:
+      add: Added
+      fix: Fixed
+      dep: Deprecated
+      chg: Changed
+      rmv: Removed
+  header:
+    pattern: "^(\\w*)\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,33 @@ jobs:
             printf "current user: %s\n" "${who}"
             echo "list current directory contents:"
             ls -la .
+  tag-and-release:
+    executor: vro/default
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "0a:16:aa:bf:a7:8b:2a:68:aa:62:28:63:20:11:62:4a"
+      - checkout
+      - vro/git-chglog-update
+      - run: cat CHANGELOG.md
+      - run:
+          name: "Commit the changelog updates"
+          command: |
+            chglogUpdated=$(git diff --name-only -- CHANGELOG.md)
+            if [ -z "${chglogUpdated}" ]; then
+              echo "no changes detected in the CHANGELOG.md file"
+              exit 1
+            fi
+            git add CHANGELOG.md
+            git config --global user.name "${CIRCLE_USERNAME}"
+            git config --global user.email "${CIRCLE_USERNAME}@users.noreply.github.com"
+            git checkout -b update-chglog-${CIRCLE_SHA1:0:7}
+            git commit -m "[skip ci] Updated the CHANGELOG.md"
+            git push origin update-chglog-${CIRCLE_SHA1:0:7}
+            echo "${GH_TOKE}" > really-i-need-a-file.txt
+            gh auth login --with-token < really-i-need-a-file.txt
+            gh pr create --base main --head update-chglog-${CIRCLE_SHA1:0:7} --fill
+            gh pr merge --auto --rebase
 
 workflows:
   # This workflow will run on every commit except main
@@ -132,3 +159,24 @@ workflows:
               only: /^v?\d+\.\d+\.\d+$/
             branches:
               ignore: /.*/
+  # Only run on the main branch
+  # 1. Checkout code.
+  # 2. Run the changelog update command.
+  # 3. If any, commit the changelog changes, ensure you use the CI [skip] tag to prevent a running CI from CI.
+  # 4. Optionally add an approval gate here, this is to try and prevent merge collision, never approve more than one of these at a time as they will collide when trying to update main.
+  # 5. Verify that main has not changed:
+  #      a. If it has, then stop and fail with a message that main has change since this workflow began.
+  #      b. If not, then proceed.
+  # 6. Make a branch.
+  #     a. push the branch.
+  #     b. make a PR.
+  #     c. merge the PR.
+  # 5. Perform a fetch and rebase. Tag the latest main.
+  # 6.
+  tag-and-release-flow:
+    jobs:
+      - tag-and-release:
+          context: orb-publishing
+#          filters:
+#            branches:
+#              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,11 +75,14 @@ jobs:
             ls -la .
 
 workflows:
-  # This workflow will run on every commit
+  # This workflow will run on every commit except main
   test-pack:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - orb-tools/lint
+      - orb-tools/lint:
+          filters:
+            branches:
+              ignore: main
       - orb-tools/pack
       - shellcheck/check:
           dir: ./src/scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,45 @@
-<a name="0.3.0"></a>
-## 0.3.0 - 2021-12-28
+<a name="unreleased"></a>
+## [Unreleased]
 
+
+<a name="0.3.6"></a>
+## [0.3.6] - 2022-01-02
 ### Added
+- Updated CHANGELOG command example.
+
+
+<a name="0.3.5"></a>
+## [0.3.5] - 2022-01-02
+
+<a name="0.3.4"></a>
+## [0.3.4] - 2022-01-02
+
+<a name="0.3.3"></a>
+## [0.3.3] - 2022-01-02
+### Fixed
+- Dupe CI runs.
+- CI auto Orb publish after tagging.
+
+
+<a name="0.3.1"></a>
+## [0.3.1] - 2022-01-02
+
+<a name="0.3.2"></a>
+## [0.3.2] - 2022-01-02
+### Changed
+- Allow tags to be run in CI deploy workflow.
+
+
+<a name="0.3.0"></a>
+## [0.3.0] - 2022-01-02
+### Added
+- Publish on making a new tag.
 - Check for tags before updating CHANGELOG.md.
 - SSH fingerprint to CI config.
+
+### Fixed
+- Type in default executor.
+
 
 <a name="0.2.0"></a>
 ## 0.2.0 - 2021-12-26
@@ -24,4 +60,12 @@
 ### Removed
 - Sample command and job.
 
-[Unreleased]: https://github.com/kohirens/version-release-orb/compare/0.2.0...HEAD
+
+[Unreleased]: https://github.com/kohirens/version-release-orb/compare/0.3.6...HEAD
+[0.3.6]: https://github.com/kohirens/version-release-orb/compare/0.3.5...0.3.6
+[0.3.5]: https://github.com/kohirens/version-release-orb/compare/0.3.4...0.3.5
+[0.3.4]: https://github.com/kohirens/version-release-orb/compare/0.3.3...0.3.4
+[0.3.3]: https://github.com/kohirens/version-release-orb/compare/0.3.1...0.3.3
+[0.3.1]: https://github.com/kohirens/version-release-orb/compare/0.3.2...0.3.1
+[0.3.2]: https://github.com/kohirens/version-release-orb/compare/0.3.0...0.3.2
+[0.3.0]: https://github.com/kohirens/version-release-orb/compare/0.2.0...0.3.0

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,4 +1,4 @@
 description: >
   version release executor with git-tool-belt.
 docker:
-  - image: 'kohirens/git-tool-belt:0.3.0'
+  - image: 'kohirens/git-tool-belt:0.5.0'


### PR DESCRIPTION
- Changed test-pack workflow to not run on the main branch.
- Added git-chglog configuration for automating changelog updates.
- Upgraded the default executor to the latest git-tool-belt version.
- Added a new tag-and-release workflow in the CI.
- [skip ci] Updated the CHANGELOG.md
