### PR TITLE
updated changelog from refactor ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,10 @@ parameters:
       A "dev:alpha" version must exist for the initial pipeline run.
     type: string
     default: "dev:alpha"
+  ssh-finger:
+    description: SSH fingerprint.
+    type: string
+    default: "0a:16:aa:bf:a7:8b:2a:68:aa:62:28:63:20:11:62:4a"
 
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
@@ -174,9 +178,15 @@ workflows:
   # 5. Perform a fetch and rebase. Tag the latest main.
   # 6.
   tag-and-release-flow:
+    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - tag-and-release:
+      - vro/commit-and-merge-changelog:
           context: orb-publishing
           filters:
             branches:
-              only: main
+              only: /refactor-ci|main/
+          pre-steps:
+            - checkout
+            - attach_workspace:
+                at: '.'
+          sshFinger: << pipeline.parameters.ssh-finger >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,4 +179,4 @@ workflows:
           context: orb-publishing
           filters:
             branches:
-              only: update-tag-and-release
+              only: main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 ## [Unreleased]
 
 ### Changed
+- Only run tag-and-release-flow on main branch.
 - Refactor tag-and-release job and workflow.
+
+### Fixed
+- commit-and-merge-changelog job.
 
 
 <a name="0.3.6"></a>

--- a/src/jobs/commit-and-merge-changelog.yml
+++ b/src/jobs/commit-and-merge-changelog.yml
@@ -23,19 +23,23 @@ parameters:
     type: enum
     enum: [ "merge", "rebase", "squash" ]
     default: "rebase"
-  ssh_finger:
+  sshFinger:
     description: Name of the branch to merge into.
     type: string
-job:
-  executor: default
-  steps:
-    - add_ssh_keys:
-        fingerprints:
-          - << parameters.ssh_finger >>
-    - run:
-        environment:
-          PARAM_CHANGELOG_FILE: << parameters.changelogFile >>
-          PARAM_BRANCH: << parameters.branch >>
-          PARAM_MERGE_TYPE: << parameters.mergeType >>
-        name: Commit and merge the CHANGELOG updates
-        command: << include(scripts/commit-and-rebase-changelog.sh) >>
+  ghToken:
+    description: Name of the environment variable holding the GitHub API token.
+    type: env_var_name
+    default: GH_TOKE
+executor: default
+steps:
+  - add_ssh_keys:
+      fingerprints:
+        - << parameters.sshFinger >>
+  - git-chglog-update
+  - run:
+      environment:
+        PARAM_CHANGELOG_FILE: << parameters.changelogFile >>
+        PARAM_BRANCH: << parameters.branch >>
+        PARAM_MERGE_TYPE: << parameters.mergeType >>
+      name: Commit and merge the CHANGELOG updates
+      command: << include(scripts/commit-and-merge-changelog.sh) >>

--- a/src/scripts/commit-and-merge-changelog.sh
+++ b/src/scripts/commit-and-merge-changelog.sh
@@ -4,7 +4,8 @@ CommitAndMergeChangelog() {
         echo "no changes detected in the ${PARAM_CHANGELOG_FILE} file"
         exit 1
     fi
-    GEN_BRANCH_NAME="update-chglog-${CIRCLE_SHA1:0:7}"
+    #GEN_BRANCH_NAME="update-chglog-${CIRCLE_SHA1:0:7}"
+    GEN_BRANCH_NAME="updated-changelog-from-${CIRCLE_BRANCH}"
     git add CHANGELOG.md
     git config --global user.name "${CIRCLE_USERNAME}"
     git config --global user.email "${CIRCLE_USERNAME}@users.noreply.github.com"

--- a/src/scripts/commit-and-merge-changelog.sh
+++ b/src/scripts/commit-and-merge-changelog.sh
@@ -17,7 +17,8 @@ CommitAndMergeChangelog() {
         gh auth login --with-token < really-i-need-a-file.txt
         gh pr create --base "${PARAM_BRANCH}" --head "${GEN_BRANCH_NAME}" --fill
         sleep 10
-        gh pr merge --auto "${PARAM_MERGE_TYPE}"
+        #gh pr merge --auto "${PARAM_MERGE_TYPE}"
+        echo "PR merge command goes here"
     fi
 }
 


### PR DESCRIPTION
- chg: Only run tag-and-release-flow on main branch.
- fix: commit-and-merge-changelog job.
- Replaced inline CI job tag-and-release with an Orb job.
- Changed the generate PR name that will not make a new PR with same branch.
- [skip ci] Updated the CHANGELOG.md
