### PR TITLE
Upgraded Default Executor

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "Version Release Orb",
 	"dockerComposeFile": "../.docker/docker-compose.yml",
 	"service": "cli",
-	"workspaceFolder": "/home/app/src/github.com/kohirens/git-tool-belt",
+	"workspaceFolder": "/home/app/src/github.com/kohirens/version-release-orb",
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {
 		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -4,7 +4,7 @@ ARG USER_GID='1000'
 ARG USER_GROUP='app_users'
 ARG REPO='github.com/kohirens/version-release-orb'
 
-FROM kohirens/git-tool-belt:0.8.0 AS dev
+FROM kohirens/git-tool-belt:1.1.3 AS dev
 
 ARG USER_NAME
 ARG USER_UID

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,7 +1,7 @@
 description: >
   version release executor with git-tool-belt.
 docker:
-  - image: 'kohirens/git-tool-belt:0.9.0'
+  - image: 'kohirens/git-tool-belt:1.1.3'
     auth:
       username: ${DH_USER}
       password: ${DH_PASS}

--- a/src/scripts/git-chglog-update.sh
+++ b/src/scripts/git-chglog-update.sh
@@ -5,7 +5,7 @@ GitChglogUpdate() {
         echo "no tags found"
         git-chglog --output "${PARAM_OUTPUTFILE}" -c "${PARAM_CONFIGFILE}" --next-tag=0.1.0
     elif [ -f "/usr/local/bin/git-tool-belt" ]; then
-        git-tool-belt version
+        git-tool-belt semver -save build-version.json
         nextVersion=$(jq -r .nextVersion < build-version.json)
         echo "nextVersion = ${nextVersion}"
         git-chglog --output "${PARAM_OUTPUTFILE}" -c "${PARAM_CONFIGFILE}" --next-tag="${nextVersion}"

--- a/src/scripts/tag-and-release.sh
+++ b/src/scripts/tag-and-release.sh
@@ -25,7 +25,7 @@ TagAndRelease() {
         exit 0
     fi
 
-    git-tool-belt version
+    git-tool-belt semver -save build-version.json
     nextVersion=$(jq -r .nextVersion < build-version.json)
     currVersion=$(jq -r .currentVersion < build-version.json)
     releaseDay=$(date +"%Y-%m-%d")


### PR DESCRIPTION
The git-tool-belt version has made it to 1.1.3. Introducing a breaking
change, that does not change this tools functionality.

## Fixed

* Issue with VS code Remote Environment.

## Changed

* Upgraded default executor to git-tool-belt version 1.1.3.