### PR TITLE
Upgraded Git-Tool-Belt Image

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,7 +1,7 @@
 description: >
   version release executor with git-tool-belt.
 docker:
-  - image: 'kohirens/git-tool-belt:1.1.3'
+  - image: 'kohirens/git-tool-belt:1.2.2'
     auth:
       username: ${DH_USER}
       password: ${DH_PASS}

--- a/src/scripts/add-missing-chglog-config.sh
+++ b/src/scripts/add-missing-chglog-config.sh
@@ -1,20 +1,5 @@
 AddMissingChgLogConfig() {
-    wd=$(pwd)
-    echo "working directory = ${wd}"
-
-    if [ ! -f "${PARAM_CONFIGFILE}" ]; then
-        CONFIG_DIR=$(dirname "${PARAM_CONFIGFILE}")
-        echo "no changelog file found at ${CONFIG_DIR}. adding the default..."
-        mkdir -p "${CONFIG_DIR}"
-        sed -e "s/\${VCS_URL}/${CIRCLE_REPOSITORY_URL}/" ./files/config.yml > "${PARAM_CONFIGFILE}"
-        cp ./files/CHANGELOG.tpl.md "${CONFIG_DIR}"
-
-        if [ ! -f "${PARAM_CONFIGFILE}" ]; then
-            echo "unable to add ${PARAM_CONFIGFILE}"
-        fi
-    else
-        echo "found git-chglog config here ${PARAM_CONFIGFILE}"
-    fi
+    git-tool-belt checkConf -path "${PARAM_CONFIGFILE}" -repo "${CIRCLE_REPOSITORY_URL}"
 }
 
 # Will not run if sourced for bats-core tests.

--- a/src/tests/add-missing-chglog-config.bats
+++ b/src/tests/add-missing-chglog-config.bats
@@ -1,5 +1,14 @@
 # Runs prior to every test
 setup() {
+    wd=$(pwd)
+    curl -LO https://github.com/kohirens/git-tool-belt/releases/download/1.2.2/git-tool-belt-linux-amd64.tar.gz
+    mv git-tool-belt-linux-amd64.tar.gz /tmp/git-tool-belt-linux-amd64.tar.gz
+    cd /tmp
+    tar -xzf git-tool-belt-linux-amd64.tar.gz
+    chmod +x ./git-tool-belt-linux-amd64
+    mkdir -p /home/circleci/bin
+    mv ./git-tool-belt-linux-amd64 /home/circleci/bin/git-tool-belt
+    cd "${wd}"
     # Load our script file.
     source ./src/scripts/add-missing-chglog-config.sh
 }


### PR DESCRIPTION
Upgrade git-tool-belt to check and, if missing, add a Git-ChgLog
configuration.

chg: Upgraded the git-tool-belt image.
chg: Upgraded the git-chglog config check command.