### PR TITLE
Upgraded Git-Tool-Bet Image

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,7 +1,7 @@
 description: >
   version release executor with git-tool-belt.
 docker:
-  - image: 'kohirens/git-tool-belt:1.2.2'
+  - image: 'kohirens/git-tool-belt:1.2.3'
     auth:
       username: ${DH_USER}
       password: ${DH_PASS}


### PR DESCRIPTION
Should now add a new Git-ChgLog configurations without error.
