### PR TITLE
Switch to SSH for Github Login

### DIFF
--- a/src/scripts/publish-changelog.sh
+++ b/src/scripts/publish-changelog.sh
@@ -34,8 +34,10 @@ MergeChangelog() {
     # TODO: This can be tested if you mock the gh, git, and setup a dummy repo at test time.
     if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
         git push origin "${GEN_BRANCH_NAME}"
-        echo "${GH_TOKEN}" > really-i-need-a-file.txt
-        gh auth login --with-token < really-i-need-a-file.txt
+        gh config set git_protocol ssh --host github.com
+        gh auth status github.com
+        #echo "${GH_TOKEN}" > really-i-need-a-file.txt
+        #gh auth login --with-token < really-i-need-a-file.txt
         gh pr create --base "${PARAM_BRANCH}" --head "${GEN_BRANCH_NAME}" --fill
         sleep 5
         gh pr merge --auto "--${PARAM_MERGE_TYPE}"


### PR DESCRIPTION
Getting an error when setting the GH_TOKEN environment variable. May be
using HTTP auth, switching to SSH should allow using the environment
variable.

fix: Using GitHub token set in an environment variable to use for
authentication.