### PR TITLE
Patch Errors with Auto Tag and Release

### DIFF
--- a/src/jobs/publish-changelog.yml
+++ b/src/jobs/publish-changelog.yml
@@ -42,6 +42,10 @@ parameters:
     description: Location to output/update the CHANGELOG file.
     type: string
     default: "CHANGELOG.md"
+  chglogConfDir:
+    description: Location to output/update the CHANGELOG file.
+    type: string
+    default: ".chglog"
 executor: default
 steps:
   - checkout
@@ -64,4 +68,4 @@ steps:
       command: << include(scripts/publish-changelog.sh) >>
   - persist_to_workspace:
       root: "."
-      paths: [ << parameters.commitFile >> ]
+      paths: [ "<< parameters.commitFile >>", "<< parameters.chglogConfDir >>"]

--- a/src/scripts/tag-and-release.sh
+++ b/src/scripts/tag-and-release.sh
@@ -14,6 +14,8 @@ TagAndRelease() {
     # Skip if there are changes in the changelog that have not been merged.
     if [ -n "${changelogUpdated}" ]; then
         echo "exiting, changes detected in the ${PARAM_CHANGELOG_FILE} file"
+        # ensure this file exist so persist does not fail.
+        echo "" > "${PARAM_TAG_FILE}"
         exit 0
     fi
 
@@ -22,6 +24,8 @@ TagAndRelease() {
     # Skip if this commit is already tagged.
     if [ "${hasTag}" != "not found" ]; then
         echo "exiting, commit is already tagged: ${hasTag}"
+        # ensure this file exist so persist does not fail.
+        echo "" > "${PARAM_TAG_FILE}"
         exit 0
     fi
 
@@ -41,6 +45,8 @@ TagAndRelease() {
     # Skip if there are no notable commits to tag.
     if [ "${isTaggable}" = "false" ]; then
         echo "exiting, no notable commits to tag"
+        # ensure this file exist so persist does not fail.
+        echo "" > "${PARAM_TAG_FILE}"
         exit 0
     fi
 


### PR DESCRIPTION
## Fixed

* Error when generating a .chglog config and template for the first time it failed to persist for tagging and release.
* Error on persisting the `commit-to-tag-.txt` file when there were no taggable changes found.