### PR TITLE
Cleaned-up 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  vro: kohirens/version-release@<<pipeline.parameters.dev-orb-version>>
+  vro: << pipeline.parameters.orb_repo >>@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@10.1.0
   bats: circleci/bats@1.0
   shellcheck: circleci/shellcheck@2.0
@@ -25,6 +25,10 @@ parameters:
     description: SSH fingerprint.
     type: string
     default: "0a:16:aa:bf:a7:8b:2a:68:aa:62:28:63:20:11:62:4a"
+  orb_repo:
+    description: Orb repository
+    type: string
+    default: "kohirens/version-release"
 
 jobs:
   # Define one or more jobs which will utilize your orb's commands and parameters to validate your changes.
@@ -42,7 +46,7 @@ jobs:
       - attach_workspace:
           at: '.'
       - run:
-          name: "Publish orb at kohirens/version-release"
+          name: "Publish Orb"
           command: |
             GIT_TAG=$(git tag --points-at HEAD)
             if [ -z "${GIT_TAG}" ]; then
@@ -50,7 +54,7 @@ jobs:
               exit 1
             fi
             circleci orb --skip-update-check validate orb.yml
-            circleci orb publish --skip-update-check orb.yml kohirens/version-release@${GIT_TAG} --token ${CIRCLE_TOKEN}
+            circleci orb publish --skip-update-check orb.yml << pipeline.parameters.orb_repo >>@${GIT_TAG} --token ${CIRCLE_TOKEN}
   debug_info:
     executor: vro/default
     steps:
@@ -85,7 +89,7 @@ workflows:
           path: ./src/tests
           filters: *main-and-skip
       - orb-tools/publish-dev:
-          orb-name: kohirens/version-release
+          orb-name: << pipeline.parameters.orb_repo >>
           context: orb-publishing
           requires:
             - orb-tools/lint

--- a/src/examples/auto-release.yml
+++ b/src/examples/auto-release.yml
@@ -11,23 +11,48 @@ usage:
       description: Fingerprint of an SSH key to allow writing back to the repo.
       type: string
       default: "AB:CD:EF:GH:12:34:56:78"
+    triggered-by-bot:
+      description: Trigger publishing a release tag workflow.
+      type: boolean
+      default: false
 
   workflows:
-    # Only run when branch is main
-    # 1. Update the changelog.
-    # 2. Merge the changelog to main, causing tag-and-release to run.
-    # 3. Verify there are changes worth making a release tag for.
-    #    a. If so, then publish a release tag.
-    auto-release:
+    # Other workflows here
+    # ...
+
+    # Everything that should be done before a production release should precede this workflow.
+    publish-changelog: # Run ONLY on main and when triggered-by-bot is true.
+      when:
+        and:
+          - equal: [main, << pipeline.git.branch >>]
+          - << pipeline.parameters.triggered-by-bot >>
       jobs:
         - vro/publish-changelog:
             context: orb-publishing
-            filters:
-              branches:
-                only: main
-            ghToken: "GH_TOKEN" # Name of the environment variable that contains a GitHub personal access token to write back to a repo.
+            filters: { branches: { only: main } }
             sshFinger: << pipeline.parameters.ssh-finger >>
+
+    publish-release-tag: # Run ONLY on main when kicked-off by publish-changelog workflow.
+      when:
+        and:
+          - equal: [main, << pipeline.git.branch >>]
+          - << pipeline.parameters.triggered-by-bot >>
+          - matches:
+              pattern: "^api|webhook$"
+              value: << pipeline.trigger_source >>
+      jobs:
         - vro/tag-and-release:
             context: orb-publishing
-            ghToken: "GH_TOKEN"
+            filters: { branches: { only: main } }
             requires: [ vro/publish-changelog ]
+
+    # Everything that should go to production should proceed this workflow.
+    on-tag-release: # The filter will cause this to ONLY run on a release tags.
+      jobs:
+        - add-your-jobs-here:
+            context: orb-publishing
+            filters:
+              tags:
+                only: /^v?\d+\.\d+\.\d+$/
+              branches:
+                ignore: /.*/

--- a/src/examples/git-chglog-update.yml
+++ b/src/examples/git-chglog-update.yml
@@ -7,14 +7,17 @@ description: |2
 
 usage:
   version: 2.1
+
   orbs:
     vro: kohirens/version-release@latest
+
   workflows:
     use-my-orb:
       jobs:
         - checkout
         - update-the-chglog:
             requires: [ checkout ]
+
 jobs:
   update-the-chglog:
     executor: vro/default

--- a/src/examples/publish-changelog.yml
+++ b/src/examples/publish-changelog.yml
@@ -2,6 +2,7 @@ description: >
   Commit changes to the changelog and merge into a remote branch.
 usage:
   version: 2.1
+
   orbs:
     vro: kohirens/version-release@latest
 

--- a/src/examples/publish-changelog.yml
+++ b/src/examples/publish-changelog.yml
@@ -4,10 +4,30 @@ usage:
   version: 2.1
   orbs:
     vro: kohirens/version-release@latest
+
+  parameters:
+    ssh-finger:
+      description: SSH fingerprint.
+      type: string
+      default: "aa:bb:cc:dd:12:34:56"
+    triggered-by-bot:
+      description: Trigger publishing a release tag workflow.
+      type: boolean
+      default: false
+
   workflows:
-    tag-and-release:
+    version: 2
+    auto-release: # Run ONLY on main and when triggered-by-bot is true via an API call.
+      when:
+        and:
+          - equal: [main, << pipeline.git.branch >>]
+          - << pipeline.parameters.triggered-by-bot >>
       jobs:
-        - checkout
-        - publish-changelog:
-            requires: [ checkout ]
-            ssh_finger: "AB:CD:EF:GH:12:34:56:78"
+        - vro/publish-changelog:
+            context: orb-publishing
+            filters: { branches: { only: main } }
+            pre-steps:
+              - checkout
+              - attach_workspace: { at: '.' }
+              - run: echo "trigger source << pipeline.trigger_source >>"
+            sshFinger: << pipeline.parameters.ssh-finger >>

--- a/src/examples/tag-and-release.yml
+++ b/src/examples/tag-and-release.yml
@@ -1,10 +1,6 @@
 description: >
   Trigger a workflow to publish a tag to make a new release in the version control system.
 parameters:
-  ssh-finger:
-    description: SSH fingerprint.
-    type: string
-    default: "3e:01:4a:ba:a7:78:bc:2c:e1:1b:01:71:d5:d7:78:87"
   triggered-by-bot:
     description: Trigger publishing a release tag workflow.
     type: boolean

--- a/src/examples/tag-and-release.yml
+++ b/src/examples/tag-and-release.yml
@@ -1,0 +1,32 @@
+description: >
+  Trigger a workflow to publish a tag to make a new release in the version control system.
+parameters:
+  ssh-finger:
+    description: SSH fingerprint.
+    type: string
+    default: "3e:01:4a:ba:a7:78:bc:2c:e1:1b:01:71:d5:d7:78:87"
+  triggered-by-bot:
+    description: Trigger publishing a release tag workflow.
+    type: boolean
+    default: false
+usage:
+  version: 2.1
+  orbs:
+    vro: kohirens/version-release@latest
+  workflows:
+    version: 2
+    publish-release-tag:
+      jobs:
+        publish-release-tag: # Run ONLY on the main branch, and parameter triggered-by-bot is true, and when kicked-off by the webhook or api.
+          when:
+            and:
+              - equal: [main, << pipeline.git.branch >>]
+              - << pipeline.parameters.triggered-by-bot >>
+              - matches:
+                  pattern: "^api|webhook$"
+                  value: << pipeline.trigger_source >>
+          jobs:
+            - vro/tag-and-release:
+                context: orb-publishing
+                filters: { branches: { only: main } }
+                requires: [ vro/publish-changelog ]

--- a/src/examples/tag-and-release.yml
+++ b/src/examples/tag-and-release.yml
@@ -7,22 +7,22 @@ parameters:
     default: false
 usage:
   version: 2.1
+
   orbs:
     vro: kohirens/version-release@latest
+
   workflows:
     version: 2
-    publish-release-tag:
+    publish-release-tag: # Run ONLY on the main branch, and parameter triggered-by-bot is true, and when kicked-off by the webhook or api.
+      when:
+        and:
+          - equal: [main, << pipeline.git.branch >>]
+          - << pipeline.parameters.triggered-by-bot >>
+          - matches:
+              pattern: "^api|webhook$"
+              value: << pipeline.trigger_source >>
       jobs:
-        publish-release-tag: # Run ONLY on the main branch, and parameter triggered-by-bot is true, and when kicked-off by the webhook or api.
-          when:
-            and:
-              - equal: [main, << pipeline.git.branch >>]
-              - << pipeline.parameters.triggered-by-bot >>
-              - matches:
-                  pattern: "^api|webhook$"
-                  value: << pipeline.trigger_source >>
-          jobs:
-            - vro/tag-and-release:
-                context: orb-publishing
-                filters: { branches: { only: main } }
-                requires: [ vro/publish-changelog ]
+        - vro/tag-and-release:
+            context: orb-publishing
+            filters: { branches: { only: main } }
+            requires: [ vro/publish-changelog ]

--- a/src/examples/trigger-tag-and-release.yml
+++ b/src/examples/trigger-tag-and-release.yml
@@ -1,0 +1,28 @@
+description: >
+  Trigger a workflow to publish a tag to make a new release in the version control system.
+parameters:
+  vcs-type:
+    type: enum
+    default: "github"
+    enum: [ "github" ]
+    description: VCS type, only "github" is currently supported.
+usage:
+  version: 2.1
+  orbs:
+    vro: kohirens/version-release@latest
+  workflows:
+    use-my-orb:
+      jobs:
+        - publish-release-tag: # Run ONLY on the main branch, and parameter trigger-tagging is true, and when kicked-off by the webhook or api.
+            when:
+              and: # run when branch is main, the trigger source is [webhook or api
+                - equal: [main, << pipeline.git.branch >>]
+                - << pipeline.parameters.trigger-tagging >>
+                - matches:
+                    pattern: "^api|webhook$"
+                    value: << pipeline.trigger_source >>
+            jobs:
+              - vro/trigger-tag-and-release:
+                  context: orb-publishing
+                  filters: { branches: { only: main } } # This is redundant.
+                  requires: [ vro/publish-changelog ]

--- a/src/examples/trigger-tag-and-release.yml
+++ b/src/examples/trigger-tag-and-release.yml
@@ -1,10 +1,5 @@
 description: >
   Trigger a workflow to publish a tag to make a new release in the version control system.
-parameters:
-  ssh-finger:
-    description: SSH fingerprint.
-    type: string
-    default: "3e:01:4a:ba:a7:78:bc:2c:e1:1b:01:71:d5:d7:78:87"
 usage:
   version: 2.1
   orbs:

--- a/src/examples/trigger-tag-and-release.yml
+++ b/src/examples/trigger-tag-and-release.yml
@@ -1,28 +1,20 @@
 description: >
   Trigger a workflow to publish a tag to make a new release in the version control system.
 parameters:
-  vcs-type:
-    type: enum
-    default: "github"
-    enum: [ "github" ]
-    description: VCS type, only "github" is currently supported.
+  ssh-finger:
+    description: SSH fingerprint.
+    type: string
+    default: "3e:01:4a:ba:a7:78:bc:2c:e1:1b:01:71:d5:d7:78:87"
 usage:
   version: 2.1
   orbs:
     vro: kohirens/version-release@latest
   workflows:
-    use-my-orb:
+    version: 2
+    triggered-workflow:
       jobs:
-        - publish-release-tag: # Run ONLY on the main branch, and parameter trigger-tagging is true, and when kicked-off by the webhook or api.
-            when:
-              and: # run when branch is main, the trigger source is [webhook or api
-                - equal: [main, << pipeline.git.branch >>]
-                - << pipeline.parameters.trigger-tagging >>
-                - matches:
-                    pattern: "^api|webhook$"
-                    value: << pipeline.trigger_source >>
-            jobs:
-              - vro/trigger-tag-and-release:
-                  context: orb-publishing
-                  filters: { branches: { only: main } } # This is redundant.
-                  requires: [ vro/publish-changelog ]
+        kick-off-publish-release-tag:
+          jobs:
+            - vro/trigger-tag-and-release.yml:
+                context: orb-publishing
+                filters: { branches: { only: main } }

--- a/src/examples/trigger-tag-and-release.yml
+++ b/src/examples/trigger-tag-and-release.yml
@@ -10,6 +10,6 @@ usage:
       jobs:
         kick-off-publish-release-tag:
           jobs:
-            - vro/trigger-tag-and-release.yml:
-                context: orb-publishing
-                filters: { branches: { only: main } }
+            vro/trigger-tag-and-release:
+              context: orb-publishing
+              filters: { branches: { only: main } }

--- a/src/examples/trigger-tag-and-release.yml
+++ b/src/examples/trigger-tag-and-release.yml
@@ -2,14 +2,14 @@ description: >
   Trigger a workflow to publish a tag to make a new release in the version control system.
 usage:
   version: 2.1
+
   orbs:
     vro: kohirens/version-release@latest
+
   workflows:
     version: 2
-    triggered-workflow:
+    kick-off-publish-release-tag:
       jobs:
-        kick-off-publish-release-tag:
-          jobs:
-            vro/trigger-tag-and-release:
-              context: orb-publishing
-              filters: { branches: { only: main } }
+        - vro/trigger-tag-and-release:
+            context: orb-publishing
+            filters: { branches: { only: main } }

--- a/src/jobs/publish-changelog.yml
+++ b/src/jobs/publish-changelog.yml
@@ -46,7 +46,13 @@ parameters:
     description: Location to output/update the CHANGELOG file.
     type: string
     default: ".chglog"
+  working_directory:
+    description: In case you need to customize.
+    type: string
+    default: "~/project"
+
 executor: default
+working_directory: "<< parameters.working_directory >>"
 steps:
   - checkout
   - add_ssh_keys:

--- a/src/jobs/publish-changelog.yml
+++ b/src/jobs/publish-changelog.yml
@@ -76,7 +76,7 @@ steps:
         PARAM_BRANCH: "<< parameters.branch >>"
         PARAM_MERGE_TYPE: "<< parameters.mergeType >>"
         PARAM_COMMIT_FILE: "<< parameters.commitFile >>"
-        PARAM_CONFIGFILE: "<< parameters.configFile >>"
+        PARAM_CONFIGFILE: "<< parameters.configFile >>" # TODO: Rename in next release to PARAM_CONFIG_FILE
       name: Commit and merge the CHANGELOG updates
       command: << include(scripts/publish-changelog.sh) >>
   - persist_to_workspace:

--- a/src/jobs/publish-changelog.yml
+++ b/src/jobs/publish-changelog.yml
@@ -37,7 +37,7 @@ parameters:
   ghToken:
     description: Name of the environment variable holding the GitHub API token.
     type: env_var_name
-    default: GH_TOKEN # Setting this to GITHUB_TOKEN seems to cause problems.
+    default: GH_TOKEN
   mergeType:
     description: Type of merge to perform, choose between merge|squash|rebase.
     type: enum

--- a/src/jobs/publish-changelog.yml
+++ b/src/jobs/publish-changelog.yml
@@ -9,7 +9,7 @@ description: |2
   6. Then immediately merge the changes in the desired branch.
 
   We use a PR instead of a push in case the branch is protected from direct pushes.
-parameters:
+parameters: # TODO: Change all params to use snake case in jobs and commands for consistenc.
   branch:
     description: Name of the branch to merge into.
     type: string

--- a/src/jobs/publish-changelog.yml
+++ b/src/jobs/publish-changelog.yml
@@ -18,6 +18,10 @@ parameters:
     description: Location of the CHANGELOG file.
     type: string
     default: "CHANGELOG.md"
+  chglogConfDir:
+    description: Location to output/update the CHANGELOG file.
+    type: string
+    default: ".chglog"
   commitFile:
     description: Name of the file to set the commit hash to tag.
     type: string
@@ -26,6 +30,10 @@ parameters:
     type: string
     default: ".chglog/config.yml"
     description: Location of a git-chglog configuration file.
+  do_checkout:
+    description: In case you need to customize.
+    type: boolean
+    default: true
   ghToken:
     description: Name of the environment variable holding the GitHub API token.
     type: env_var_name
@@ -35,25 +43,17 @@ parameters:
     type: enum
     enum: [ "merge", "rebase", "squash" ]
     default: "rebase"
-  sshFinger:
-    description: Fingerprint of an SSH key that can be used to perform a merge into a branch.
-    type: string
   outputFile:
     description: Location to output/update the CHANGELOG file.
     type: string
     default: "CHANGELOG.md"
-  chglogConfDir:
-    description: Location to output/update the CHANGELOG file.
+  sshFinger:
+    description: Fingerprint of an SSH key that can be used to perform a merge into a branch.
     type: string
-    default: ".chglog"
   working_directory:
     description: In case you need to customize.
     type: string
     default: "~/project"
-  do_checkout:
-    description: In case you need to customize.
-    type: boolean
-    default: true
 
 executor: default
 working_directory: "<< parameters.working_directory >>"

--- a/src/jobs/publish-changelog.yml
+++ b/src/jobs/publish-changelog.yml
@@ -50,11 +50,18 @@ parameters:
     description: In case you need to customize.
     type: string
     default: "~/project"
+  do_checkout:
+    description: In case you need to customize.
+    type: boolean
+    default: true
 
 executor: default
 working_directory: "<< parameters.working_directory >>"
 steps:
-  - checkout
+  - when:
+      condition: << parameters.do_checkout >>
+      steps:
+        - checkout
   - add_ssh_keys:
       fingerprints:
         - << parameters.sshFinger >>

--- a/src/jobs/tag-and-release.yml
+++ b/src/jobs/tag-and-release.yml
@@ -35,10 +35,10 @@ steps:
       outputFile: "<< parameters.changelogFile >>"
   - run:
       environment:
-        PARAM_BRANCH: << parameters.branch >>
-        PARAM_CHANGELOG_FILE: << parameters.changelogFile >>
-        PARAM_COMMIT_FILE: << parameters.commitFile >>
-        PARAM_TAG_FILE: << parameters.taggedFile >>
+        PARAM_BRANCH: "<< parameters.branch >>"
+        PARAM_CHANGELOG_FILE: "<< parameters.changelogFile >>"
+        PARAM_COMMIT_FILE: "<< parameters.commitFile >>"
+        PARAM_TAG_FILE: "<< parameters.taggedFile >>"
       name: Make A New Release
       command: << include(scripts/tag-and-release.sh) >>
   - persist_to_workspace:

--- a/src/jobs/tag-and-release.yml
+++ b/src/jobs/tag-and-release.yml
@@ -25,7 +25,13 @@ parameters:
     description: File to store the semantic version that was used to tag the release.
     type: string
     default: "tagged.txt"
+  working_directory:
+    description: In case you need to customize.
+    type: string
+    default: "~/project"
+
 executor: default
+working_directory: "<< parameters.working_directory >>"
 steps:
   - checkout
   - attach_workspace:

--- a/src/jobs/tag-and-release.yml
+++ b/src/jobs/tag-and-release.yml
@@ -1,5 +1,5 @@
 description: |2
-  Trigger a job to tag and release a spcified branch.
+  Publish a tag on a specified branch.
 parameters:
   attach_workspace:
     description: Set to `false` to skip attaching the workspace.

--- a/src/jobs/tag-and-release.yml
+++ b/src/jobs/tag-and-release.yml
@@ -1,14 +1,18 @@
 description: |2
   Trigger a job to tag and release a spcified branch.
 parameters:
+  attach_workspace:
+    description: Set to `false` to skip attaching the workspace.
+    type: boolean
+    default: true
+  attach_workspace_path:
+    description: Set where to attach the workspace.
+    type: string
+    default: "."
   branch:
     description: Name of the branch to tag.
     type: string
     default: "main"
-  ghToken:
-    description: Name of the environment variable holding the GitHub API token.
-    type: env_var_name
-    default: GH_TOKEN
   changelogFile:
     description: Location to output/update the CHANGELOG file.
     type: string
@@ -21,6 +25,14 @@ parameters:
     description: Name of the file holding the commit hash to tag.
     type: string
     default: "commit-to-tag.txt"
+  do_checkout:
+    description: Set to `false` to skip performing a checkout.
+    type: boolean
+    default: true
+  ghToken:
+    description: Name of the environment variable holding the GitHub API token.
+    type: env_var_name
+    default: GH_TOKEN
   taggedFile:
     description: File to store the semantic version that was used to tag the release.
     type: string
@@ -33,9 +45,15 @@ parameters:
 executor: default
 working_directory: "<< parameters.working_directory >>"
 steps:
-  - checkout
-  - attach_workspace:
-      at: '.'
+  - when:
+      condition: << parameters.do_checkout >>
+      steps:
+        - checkout
+  - when:
+      condition: << parameters.attach_workspace >>
+      steps:
+        - attach_workspace:
+            at: "<< parameters.attach_workspace_path >>"
   - git-chglog-update:
       configFile: "<< parameters.configFile >>"
       outputFile: "<< parameters.changelogFile >>"

--- a/src/jobs/trigger-tag-and-release.yml
+++ b/src/jobs/trigger-tag-and-release.yml
@@ -23,9 +23,9 @@ parameters:
     description: Name of the environment variable holding the GitHub API token.
     type: env_var_name
     default: GH_TOKEN
-  pipeline-param-map:
+  pipeline-param-map: # TODO: Remove this variable in next major release.
     type: string
-    default: '{"run-tag-and-release": true}'
+    default: '{"run-tag-and-release": true, "triggered-by-bot": true}'
     description: >
       Map of pipeline parameters that the new pipeline will be invoked with.
       Make use of this to target the integration workflow that should be triggered

--- a/src/jobs/trigger-tag-and-release.yml
+++ b/src/jobs/trigger-tag-and-release.yml
@@ -41,7 +41,13 @@ parameters:
     enum: ["github"]
     description: >
       VCS type.
+  working_directory:
+    description: In case you need to customize.
+    type: string
+    default: "~/project"
+
 executor: default
+working_directory: "<< parameters.working_directory >>"
 steps:
   - run:
       environment:

--- a/src/jobs/trigger-tag-and-release.yml
+++ b/src/jobs/trigger-tag-and-release.yml
@@ -45,12 +45,12 @@ executor: default
 steps:
   - run:
       environment:
-        PARAM_BRANCH: << parameters.branch >>
-        PARAM_CHANGELOG_FILE: << parameters.changelogFile >>
-        PARAM_MAP: << parameters.pipeline-param-map >>
-        CIRCLECI_API_HOST: << parameters.circleci-api-host >>
-        PARAM_VCS_TYPE: << parameters.vcs-type >>
-        CIRCLECI_APP_HOST: << parameters.circleci-app-host >>
+        PARAM_BRANCH: "<< parameters.branch >>"
+        PARAM_CHANGELOG_FILE: "<< parameters.changelogFile >>"
+        PARAM_MAP: "<< parameters.pipeline-param-map >>"
+        CIRCLECI_API_HOST: "<< parameters.circleci-api-host >>"
+        PARAM_VCS_TYPE: "<< parameters.vcs-type >>"
+        CIRCLECI_APP_HOST: "<< parameters.circleci-app-host >>"
         TOKEN: "$<<parameters.token-variable>>"
       name: Trigger CI Tagging Workflow
       command: << include(scripts/trigger-tag-and-release.sh) >>

--- a/src/scripts/publish-changelog.sh
+++ b/src/scripts/publish-changelog.sh
@@ -37,7 +37,7 @@ MergeChangelog() {
     # TODO: This can be tested if you mock the gh, git, and setup a dummy repo at test time.
     if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
         git push origin "${GEN_BRANCH_NAME}"
-        # Switch to SSH to use the token stored in the environment.
+        # Switch to SSH to use the token stored in the environment variable GH_TOKEN.
         gh config set git_protocol ssh --host github.com
         gh auth status --hostname github.com
         gh pr create --base "${PARAM_BRANCH}" --head "${GEN_BRANCH_NAME}" --fill

--- a/src/scripts/trigger-tag-and-release.sh
+++ b/src/scripts/trigger-tag-and-release.sh
@@ -8,11 +8,14 @@ TriggerTagAndRelease() {
 
     echo "{\"branch\": \"${PARAM_BRANCH}\", \"parameters\": ${PARAM_MAP}}" > pipelineparams.json
     cat pipelineparams.json
-    DoCurl
+    TriggerPipeline
     Result
 }
 
-DoCurl() {
+# Example API URL: https://circleci.com/api/v2/project/vcs-slug/org-name/repo-name/pipeline
+# Note: keep in mind that you have to use a personal API token; project tokens are currently not supported on CircleCI API (v2) at this time.
+# see: https://circleci.com/docs/api/v2/#operation/triggerPipeline
+TriggerPipeline() {
     T=$(eval echo "$TOKEN")
     curl -u "${T}": -X POST --header "Content-Type: application/json" -d @pipelineparams.json \
       "${CIRCLECI_API_HOST}/api/v2/project/${PARAM_VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pipeline" -o /tmp/curl-result.txt


### PR DESCRIPTION
Cleaned up CircleCI configuration.
Update code comments.
Alphabetize job parameters.

add: Ability to set the working directory in each job.
add: Example for using trigger-tag-and-release job in a workflow.
add: Proper tag-and-release example.
add: Send API parameter triggered-by-bot from trigger-tag-and-release job.

chg: Renamed DoCurl to TriggerPipeline.
chg: Make checkout and attach_workspace conditional on jobs that require them.
chg: Make quoting environment variables in jobs consistent.
chg: Updated publish-changelog example.
chg: Updated the auto-release example.

fix: Tag and Release job description.
fix: trigger-tag-and-release example.
