### PR TITLE
Trigger Release from publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,7 @@ jobs:
   debug-info:
     executor: vro/default
     steps:
-      - attach_workspace:
-          at: '.'
+      - attach_workspace: { at: '.' }
       - run:
           name: "Debug info"
           command: |
@@ -66,8 +65,6 @@ jobs:
     executor: cli/default
     steps:
       - checkout
-      - attach_workspace:
-          at: '.'
       - run:
           name: "Publish Orb"
           command: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Version Release
 
-[![CircleCI Build Status](https://circleci.com/gh/kohirens/version-release-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/kohirens/version-release-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/kohirens/version-release.svg)](https://circleci.com/orbs/registry/orb/kohirens/version-release) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/kohirens/version-release-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/kohirens/version-release-orb/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/kohirens/version-release-orb/tree/main) [![CircleCI Orb Version](https://badges.circleci.com/orbs/kohirens/version-release.svg)](https://circleci.com/orbs/registry/orb/kohirens/version-release) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/kohirens/version-release-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
 Provides the following features:
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -51,6 +51,14 @@ In case you have not registered the namespace (only needed once):
 circleci namespace create kohirens github kohirens
 ```
 
+NOTE: If you are having trouble making your namespace with a GitHub org name
+then use the option to make it from the Org ID. You can get the org ID from
+your Circle CI organizations context page. For example:
+
+```shell
+circleci namespace create NamespaceName --org-id "your-org-id-here"
+```
+
 ```shell
 circleci orb create kohirens/version-release
 ```

--- a/src/jobs/publish-changelog.yml
+++ b/src/jobs/publish-changelog.yml
@@ -85,6 +85,9 @@ steps:
   - add_ssh_keys:
       fingerprints:
         - << parameters.ssh_finger >>
+  - run:
+      name: "3 second delay"
+      command: sleep 3
   - add-missing-chglog-config:
       chglog_config_file: "<< parameters.chglog_config_file >>"
   - git-chglog-update:

--- a/src/scripts/git-chglog-update.sh
+++ b/src/scripts/git-chglog-update.sh
@@ -3,12 +3,6 @@ GitChglogUpdate() {
 
     cd "${PARAM_REPOSITORY_PATH}" || exit
 
-    echo
-    echo
-    pwd
-    echo
-    echo
-
     if [ -z "${hasTag}" ]; then
         echo "no tags found"
         git-chglog --output "${PARAM_CHANGELOG_FILE}" -c "${PARAM_CONFIG_FILE}" --next-tag=0.1.0

--- a/src/scripts/publish-changelog.sh
+++ b/src/scripts/publish-changelog.sh
@@ -68,6 +68,7 @@ MergeChangelog() {
         gh pr merge --auto "--${PARAM_MERGE_TYPE}"
 
         waitForPrToMerge
+        sleep 3
         echo "trigger-tag-and-release" > trigger.txt
         echo
         echo

--- a/src/scripts/publish-changelog.sh
+++ b/src/scripts/publish-changelog.sh
@@ -15,7 +15,7 @@ MergeChangelog() {
     changelogUpdated=$(git diff --name-only -- "${PARAM_CHANGELOG_FILE}")
     changelogUntracked=$(git status | grep "${PARAM_CHANGELOG_FILE}" || echo "")
     if [ "${changelogUntracked}" != "" ]; then
-        echo "detected updated to the ${PARAM_CHANGELOG_FILE} file"
+        echo "detected updates to the ${PARAM_CHANGELOG_FILE} file"
     elif [ -z "${changelogUpdated}" ]; then
         echo "no changes detected in the ${PARAM_CHANGELOG_FILE} file"
         exit 0


### PR DESCRIPTION
## Added A Delay After Publishing CHANGELOG

Added 3 seconds after the changelog updated pull request is merged into
main, and before the new workflow is triggered. This should ensure that
by the time the tag-and-release workflow runs and it does it checks to
see if the changelog needs update, it will not and succeed. If it does
then it would mean another merge with taggable changes is running, in
which case it should fail. Added a 3 second delay to the start of the
publish changelog workflow to see if that helps this problem as well.