### PR TITLE
Continuous Integration Removed Job Requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ workflows:
           filters: { branches: { only: main } }
       - orb-publish:
           context: << pipeline.parameters.secrets >>
-          requires: [ choose-a-workflow ]
           filters:
             tags:
               only: /^v?\d+\.\d+\.\d+$/


### PR DESCRIPTION
Will remove the "choose-a-workflow" requirement from orb-publish job as that may have caused the job to run when code is merged into the main brnach.